### PR TITLE
Fix up some face culling problems

### DIFF
--- a/src/main/resources/assets/betternether/models/block/brown_mushroom_bottom.json
+++ b/src/main/resources/assets/betternether/models/block/brown_mushroom_bottom.json
@@ -27,7 +27,7 @@
 			"to": [ 14, 8, 8 ],
 			"faces": {
 				"down": { "uv": [ 8, 8, 14, 14 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 8, 2, 14, 8 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 8, 2, 14, 8 ], "texture": "#stem" },
 				"north": { "uv": [ 2, 8, 8, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 8, 8, 14, 16 ], "texture": "#stem" },
 				"west": { "uv": [ 2, 8, 8, 16 ], "texture": "#stem" },
@@ -40,7 +40,7 @@
 			"to": [ 13, 6, 13 ],
 			"faces": {
 				"down": { "uv": [ 8, 3, 13, 8 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 8, 8, 13, 13 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 8, 8, 13, 13 ], "texture": "#stem" },
 				"south": { "uv": [ 8, 10, 13, 16 ], "texture": "#stem" },
 				"west": { "uv": [ 8, 10, 13, 16 ], "texture": "#stem" },
 				"east": { "uv": [ 3, 10, 8, 16 ], "texture": "#stem" }
@@ -52,7 +52,7 @@
 			"to": [ 9, 10, 8 ],
 			"faces": {
 				"down": { "uv": [ 4, 8, 9, 13 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 4, 3, 9, 8 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 4, 3, 9, 8 ], "texture": "#stem" },
 				"north": { "uv": [ 7, 6, 12, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 4, 6, 9, 16 ], "texture": "#stem" },
 				"west": { "uv": [ 3, 6, 8, 16 ], "texture": "#stem" },
@@ -65,7 +65,7 @@
 			"to": [ 9, 5, 14 ],
 			"faces": {
 				"down": { "uv": [ 3, 2, 9, 8 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 3, 8, 9, 14 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 3, 8, 9, 14 ], "texture": "#stem" },
 				"north": { "uv": [ 7, 11, 13, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 3, 11, 9, 16 ], "texture": "#stem" },
 				"west": { "uv": [ 8, 11, 14, 16 ], "texture": "#stem" },
@@ -78,7 +78,7 @@
 			"to": [ 7, 3, 16 ],
 			"faces": {
 				"down": { "uv": [ 4, 0, 7, 3 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 4, 13, 7, 16 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 4, 13, 7, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 4, 13, 7, 16 ], "texture": "#stem", "cullface": "south" },
 				"west": { "uv": [ 13, 13, 16, 16 ], "texture": "#stem" },
 				"east": { "uv": [ 0, 13, 3, 16 ], "texture": "#stem" }
@@ -90,7 +90,7 @@
 			"to": [ 3, 3, 13 ],
 			"faces": {
 				"down": { "uv": [ 0, 3, 3, 6 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 0, 10, 3, 13 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 0, 10, 3, 13 ], "texture": "#stem" },
 				"north": { "uv": [ 13, 13, 16, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 0, 13, 3, 16 ], "texture": "#stem" },
 				"west": { "uv": [ 10, 13, 13, 16 ], "texture": "#stem", "cullface": "west" }
@@ -102,7 +102,7 @@
 			"to": [ 5, 3, 4 ],
 			"faces": {
 				"down": { "uv": [ 2, 12, 5, 15 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 2, 1, 5, 4 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 2, 1, 5, 4 ], "texture": "#stem" },
 				"north": { "uv": [ 11, 13, 14, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 2, 13, 5, 16 ], "texture": "#stem" },
 				"west": { "uv": [ 1, 13, 4, 16 ], "texture": "#stem" },
@@ -115,7 +115,7 @@
 			"to": [ 14, 3, 14 ],
 			"faces": {
 				"down": { "uv": [ 11, 2, 14, 5 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 11, 11, 14, 14 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 11, 11, 14, 14 ], "texture": "#stem" },
 				"north": { "uv": [ 2, 13, 5, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 11, 13, 14, 16 ], "texture": "#stem" },
 				"west": { "uv": [ 11, 13, 14, 16 ], "texture": "#stem" },
@@ -128,7 +128,7 @@
 			"to": [ 13, 3, 3 ],
 			"faces": {
 				"down": { "uv": [ 10, 13, 13, 16 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 10, 0, 13, 3 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 10, 0, 13, 3 ], "texture": "#stem" },
 				"north": { "uv": [ 3, 13, 6, 16 ], "texture": "#stem", "cullface": "north" },
 				"west": { "uv": [ 0, 13, 3, 16 ], "texture": "#stem" },
 				"east": { "uv": [ 13, 13, 16, 16 ], "texture": "#stem" }
@@ -140,7 +140,7 @@
 			"to": [ 15, 3, 7 ],
 			"faces": {
 				"down": { "uv": [ 12, 9, 15, 12 ], "texture": "#inside", "cullface": "down" },
-				"up": { "uv": [ 12, 4, 15, 7 ], "texture": "#stem", "cullface": "up" },
+				"up": { "uv": [ 12, 4, 15, 7 ], "texture": "#stem" },
 				"north": { "uv": [ 1, 13, 4, 16 ], "texture": "#stem" },
 				"south": { "uv": [ 12, 13, 15, 16 ], "texture": "#stem" },
 				"east": { "uv": [ 9, 13, 12, 16 ], "texture": "#stem" }

--- a/src/main/resources/assets/betternether/models/block/cincinnasite_lantern_floor.json
+++ b/src/main/resources/assets/betternether/models/block/cincinnasite_lantern_floor.json
@@ -11,7 +11,6 @@
 			"from": [ 6, 1, 6 ],
 			"to": [ 10, 9, 10 ],
 			"faces": {
-				"down": { "uv": [ 11, 1, 15, 5 ], "texture": "#texture" },
 				"up": { "uv": [ 11, 1, 15, 5 ], "texture": "#texture" },
 				"north": { "uv": [ 11, 6, 15, 14 ], "texture": "#texture" },
 				"south": { "uv": [ 11, 6, 15, 14 ], "texture": "#texture" },
@@ -24,7 +23,7 @@
 			"from": [ 5, 0, 5 ],
 			"to": [ 11, 1, 11 ],
 			"faces": {
-				"down": { "uv": [ 10, 0, 16, 6 ], "texture": "#texture" },
+				"down": { "uv": [ 10, 0, 16, 6 ], "texture": "#texture", "cullface": "down"  },
 				"up": { "uv": [ 10, 0, 16, 6 ], "texture": "#texture" },
 				"north": { "uv": [ 10, 14, 16, 15 ], "texture": "#texture" },
 				"south": { "uv": [ 10, 14, 16, 15 ], "texture": "#texture" },

--- a/src/main/resources/assets/betternether/models/block/cincinnasite_lantern_wall.json
+++ b/src/main/resources/assets/betternether/models/block/cincinnasite_lantern_wall.json
@@ -10,7 +10,7 @@
 			"from": [ 6, 0, 3 ],
 			"to": [ 10, 10, 7 ],
 			"faces": {
-				"down": { "uv": [ 11, 1, 15, 5 ], "texture": "#texture" },
+				"down": { "uv": [ 11, 1, 15, 5 ], "texture": "#texture", "cullface": "down" },
 				"up": { "uv": [ 11, 1, 15, 5 ], "texture": "#texture" },
 				"north": { "uv": [ 11, 6, 15, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 11, 6, 15, 16 ], "texture": "#texture" },
@@ -69,7 +69,7 @@
 			"faces": {
 				"down": { "uv": [ 11, 0, 15, 1 ], "texture": "#texture" },
 				"up": { "uv": [ 11, 0, 15, 1 ], "texture": "#texture" },
-				"north": { "uv": [ 11, 0, 15, 6 ], "texture": "#texture" },
+				"north": { "uv": [ 11, 0, 15, 6 ], "texture": "#texture", "cullface": "north" },
 				"south": { "uv": [ 11, 0, 15, 6 ], "texture": "#texture" },
 				"west": { "uv": [ 0, 3, 1, 9 ], "texture": "#texture" },
 				"east": { "uv": [ 0, 3, 1, 9 ], "texture": "#texture" }
@@ -82,7 +82,6 @@
 			"faces": {
 				"down": { "uv": [ 1, 4, 5, 5 ], "texture": "#texture", "rotation": 90 },
 				"up": { "uv": [ 1, 4, 5, 5 ], "texture": "#texture", "rotation": 90 },
-				"north": { "uv": [ 1, 4, 2, 5 ], "texture": "#texture" },
 				"south": { "uv": [ 4, 4, 5, 5 ], "texture": "#texture" },
 				"west": { "uv": [ 1, 4, 5, 5 ], "texture": "#texture" },
 				"east": { "uv": [ 1, 4, 5, 5 ], "texture": "#texture" }

--- a/src/main/resources/assets/betternether/models/block/reeds_ladder.json
+++ b/src/main/resources/assets/betternether/models/block/reeds_ladder.json
@@ -14,7 +14,7 @@
 				"down": { "uv": [ 2, 15, 4, 16 ], "texture": "#texture", "cullface": "down", "rotation": 180 },
 				"up": { "uv": [ 2, 0, 4, 1 ], "texture": "#texture", "cullface": "up", "rotation": 180 },
 				"north": { "uv": [ 2, 0, 4, 16 ], "texture": "#texture" },
-				"south": { "uv": [ 2, 0, 4, 16 ], "texture": "#texture", "cullface": "north" },
+				"south": { "uv": [ 2, 0, 4, 16 ], "texture": "#texture", "cullface": "south" },
 				"west": { "uv": [ 3, 0, 4, 16 ], "texture": "#texture" },
 				"east": { "uv": [ 2, 0, 3, 16 ], "texture": "#texture" }
 			}
@@ -27,7 +27,7 @@
 				"down": { "uv": [ 12, 15, 14, 16 ], "texture": "#texture", "cullface": "down", "rotation": 180 },
 				"up": { "uv": [ 12, 0, 14, 1 ], "texture": "#texture", "cullface": "up", "rotation": 180 },
 				"north": { "uv": [ 12, 0, 14, 16 ], "texture": "#texture" },
-				"south": { "uv": [ 12, 0, 14, 16 ], "texture": "#texture", "cullface": "north" },
+				"south": { "uv": [ 12, 0, 14, 16 ], "texture": "#texture", "cullface": "south" },
 				"west": { "uv": [ 3, 0, 4, 16 ], "texture": "#texture" },
 				"east": { "uv": [ 2, 0, 3, 16 ], "texture": "#texture" }
 			}


### PR DESCRIPTION
- Fixes #219
- Changes the ladder model so that the cullface applies to the correct side, rather than directly opposite, which would not help performance at all and cause some weirdness especially if the ladder was attached to a transparent block:
![2020-11-17_09 29 57](https://user-images.githubusercontent.com/52297970/99372218-c558f600-28b7-11eb-96a2-0cafab838631.png)
![2020-11-17_09 30 10](https://user-images.githubusercontent.com/52297970/99372229-ca1daa00-28b7-11eb-94b0-05e87154d3fe.png)
![2020-11-17_09 30 58](https://user-images.githubusercontent.com/52297970/99372245-cee25e00-28b7-11eb-80dd-8ba99d7a8a8a.png)
![2020-11-17_09 30 45](https://user-images.githubusercontent.com/52297970/99372266-d43fa880-28b7-11eb-9801-275e54a1500f.png)
- Also adds some cullface parameters to cincinassite lanterns where they were missing, and removes a hidden face from each of them (it isn't visible anyway unless you're in spectator or really like clipping into lanterns for some reason)