### PR TITLE
Some fixes for mushroom models

### DIFF
--- a/src/main/resources/assets/betternether/models/block/wall_mushrooms_brown_1.json
+++ b/src/main/resources/assets/betternether/models/block/wall_mushrooms_brown_1.json
@@ -36,7 +36,7 @@
 			"to": [ 11, 16, 3 ],
 			"faces": {
 				"down": { "uv": [ 7, 13, 11, 16 ], "texture": "#inside" },
-				"up": { "uv": [ 7, 0, 11, 3 ], "texture": "#texture" },
+				"up": { "uv": [ 7, 0, 11, 3 ], "texture": "#texture", "cullface": "up" },
 				"south": { "uv": [ 7, 0, 11, 1 ], "texture": "#texture" },
 				"west": { "uv": [ 0, 0, 3, 1 ], "texture": "#texture" },
 				"east": { "uv": [ 13, 0, 16, 1 ], "texture": "#texture" }

--- a/src/main/resources/assets/minecraft/models/block/crimson_fungus.json
+++ b/src/main/resources/assets/minecraft/models/block/crimson_fungus.json
@@ -12,6 +12,7 @@
 			"from": [ 7, 0, 7 ],
 			"to": [ 9, 5, 9 ],
 			"faces": {
+				"down": { "uv": [ 7, 11, 9, 13 ], "texture": "#texture" },
 				"north": { "uv": [ 7, 11, 9, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 7, 11, 9, 16 ], "texture": "#texture" },
 				"west": { "uv": [ 7, 11, 9, 16 ], "texture": "#texture" },

--- a/src/main/resources/assets/minecraft/models/block/mushroom_brown_00.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_brown_00.json
@@ -10,6 +10,7 @@
     "from": [ 7, 0, 7 ],
     "to": [ 9, 2, 9 ],
     "faces": {
+		"down":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture", "cullface": "down" },
         "north": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "south": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "west":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },

--- a/src/main/resources/assets/minecraft/models/block/mushroom_brown_01.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_brown_01.json
@@ -10,6 +10,7 @@
     "from": [ 7, 0, 7 ],
     "to": [ 9, 3, 9 ],
     "faces": {
+		"down":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture", "cullface": "down" },
         "north": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "south": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "west":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },

--- a/src/main/resources/assets/minecraft/models/block/mushroom_brown_02.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_brown_02.json
@@ -10,6 +10,7 @@
     "from": [ 7, 0, 7 ],
     "to": [ 9, 1, 9 ],
     "faces": {
+		"down":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture", "cullface": "down" },
         "north": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "south": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "west":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },

--- a/src/main/resources/assets/minecraft/models/block/mushroom_brown_03.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_brown_03.json
@@ -10,6 +10,7 @@
     "from": [ 3, 0, 7 ],
     "to": [ 5, 2, 9 ],
     "faces": {
+		"down":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture", "cullface": "down" },
         "north": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "south": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "west":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
@@ -43,6 +44,7 @@
     "from": [ 11, 0, 3 ],
     "to": [ 13, 2, 5 ],
     "faces": {
+		"down":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture", "cullface": "down" },
         "north": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "south": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "west":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
@@ -53,6 +55,7 @@
     "from": [ 11, 0, 12 ],
     "to": [ 13, 3, 14 ],
     "faces": {
+		"down":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture", "cullface": "down" },
         "north": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "south": { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
         "west":  { "uv": [ 7, 14, 9, 16 ], "texture": "#texture" },
@@ -78,7 +81,7 @@
         "down":  { "uv": [ 5, 5, 11, 11 ], "texture": "#mushroom_block_inside" },
         "up":    { "uv": [ 5, 2, 11, 8 ], "texture": "#texture" },
         "north": { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" },
-        "south": { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" },
+        "south": { "uv": [ 5, 11, 11, 14 ], "texture": "#texture", "cullface": "south" },
         "west":  { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" },
         "east":  { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" }
     }

--- a/src/main/resources/assets/minecraft/models/block/mushroom_red_00.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_red_00.json
@@ -33,6 +33,7 @@
 			"from": [ 7, 0, 7 ],
 			"to": [ 9, 1, 9 ],
 			"faces": {
+				"down":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture", "cullface": "down" },
 				"north": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
 				"west": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },

--- a/src/main/resources/assets/minecraft/models/block/mushroom_red_01.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_red_01.json
@@ -33,6 +33,7 @@
 			"from": [ 7, 0, 7 ],
 			"to": [ 9, 3, 9 ],
 			"faces": {
+				"down":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture", "cullface": "down" },
 				"north": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
 				"west": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },

--- a/src/main/resources/assets/minecraft/models/block/mushroom_red_02.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_red_02.json
@@ -33,6 +33,7 @@
     "from": [ 7, 0, 7 ],
     "to": [ 9, 2, 9 ],
     "faces": {
+		"down":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture", "cullface": "down" },
         "north": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
         "south": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
         "west":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },

--- a/src/main/resources/assets/minecraft/models/block/mushroom_red_03.json
+++ b/src/main/resources/assets/minecraft/models/block/mushroom_red_03.json
@@ -10,100 +10,103 @@
 			"from": [ 1, 1, 1 ],
 			"to": [ 7, 5, 7 ],
 			"faces": {
-				"down": { "uv": [ 11, 11, 5, 5 ], "texture": "#mushroom_block_inside" },
-				"up": { "uv": [ 5, 2, 11, 8 ], "texture": "#texture" },
+				"down":  { "uv": [ 11, 11, 5, 5 ], "texture": "#mushroom_block_inside" },
+				"up":    { "uv": [ 5, 2, 11, 8 ], "texture": "#texture" },
 				"north": { "uv": [ 5, 11, 11, 15 ], "texture": "#texture" },
 				"south": { "uv": [ 5, 11, 11, 15 ], "texture": "#texture" },
-				"west": { "uv": [ 5, 11, 11, 15 ], "texture": "#texture" },
-				"east": { "uv": [ 5, 11, 11, 15 ], "texture": "#texture" }
+				"west":  { "uv": [ 5, 11, 11, 15 ], "texture": "#texture" },
+				"east":  { "uv": [ 5, 11, 11, 15 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 2, 5, 2 ],
 			"to": [ 6, 6, 6 ],
 			"faces": {
-				"up": { "uv": [ 6, 3, 10, 7 ], "texture": "#texture" },
+				"up":    { "uv": [ 6, 3, 10, 7 ], "texture": "#texture" },
 				"north": { "uv": [ 6, 10, 10, 11 ], "texture": "#texture" },
 				"south": { "uv": [ 6, 10, 10, 11 ], "texture": "#texture" },
-				"west": { "uv": [ 6, 10, 10, 11 ], "texture": "#texture" },
-				"east": { "uv": [ 6, 10, 10, 11 ], "texture": "#texture" }
+				"west":  { "uv": [ 6, 10, 10, 11 ], "texture": "#texture" },
+				"east":  { "uv": [ 6, 10, 10, 11 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 3, 0, 3 ],
 			"to": [ 5, 1, 5 ],
 			"faces": {
+				"down":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture", "cullface": "down" },
 				"north": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
-				"west": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
-				"east": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" }
+				"west":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
+				"east":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 12, 0, 8 ],
 			"to": [ 14, 2, 10 ],
 			"faces": {
+				"down":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture", "cullface": "down" },
 				"north": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
-				"west": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
-				"east": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" }
+				"west":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
+				"east":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 3, 0, 12 ],
-			"to": [ 5, 3, 14 ],
+			"to": [ 5, 2, 14 ],
 			"faces": {
+				"down":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture", "cullface": "down" },
 				"north": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
-				"west": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
-				"east": { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" }
+				"west":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" },
+				"east":  { "uv": [ 7, 15, 9, 16 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 11, 2, 7 ],
 			"to": [ 15, 7, 11 ],
 			"faces": {
-				"down": { "uv": [ 10, 7, 14, 11 ], "texture": "#mushroom_block_inside" },
-				"up": { "uv": [ 6, 3, 10, 7 ], "texture": "#texture" },
+				"down":  { "uv": [ 10, 7, 14, 11 ], "texture": "#mushroom_block_inside" },
+				"up":    { "uv": [ 6, 3, 10, 7 ],   "texture": "#texture" },
 				"north": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
 				"south": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
-				"west": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
-				"east": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" }
+				"west":  { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
+				"east":  { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 12, 7, 8 ],
 			"to": [ 14, 8, 10 ],
 			"faces": {
-				"up": { "uv": [ 7, 4, 9, 6 ], "texture": "#texture" },
+				"up":    { "uv": [ 7, 4, 9, 6 ],   "texture": "#texture" },
 				"north": { "uv": [ 7, 10, 9, 11 ], "texture": "#texture" },
 				"south": { "uv": [ 7, 10, 9, 11 ], "texture": "#texture" },
-				"west": { "uv": [ 7, 10, 9, 11 ], "texture": "#texture" },
-				"east": { "uv": [ 7, 10, 9, 11 ], "texture": "#texture" }
+				"west":  { "uv": [ 7, 10, 9, 11 ], "texture": "#texture" },
+				"east":  { "uv": [ 7, 10, 9, 11 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 2, 2, 11 ],
 			"to": [ 6, 7, 15 ],
 			"faces": {
-				"down": { "uv": [ 10, 7, 14, 11 ], "texture": "#mushroom_block_inside" },
-				"up": { "uv": [ 6, 3, 10, 7 ], "texture": "#texture" },
+				"down":  { "uv": [ 10, 7, 14, 11 ], "texture": "#mushroom_block_inside" },
+				"up":    { "uv": [ 6, 3, 10, 7 ],   "texture": "#texture" },
 				"north": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
 				"south": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
-				"west": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
-				"east": { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" }
+				"west":  { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" },
+				"east":  { "uv": [ 6, 10, 10, 15 ], "texture": "#texture" }
 			}
 		},
 		{
 			"from": [ 1, 3, 10 ],
 			"to": [ 7, 6, 16 ],
 			"faces": {
-				"down": { "uv": [ 5, 2, 11, 8 ], "texture": "#texture" },
-				"up": { "uv": [ 5, 2, 11, 8 ], "texture": "#texture" },
+				"down":  { "uv": [ 5, 2, 11, 8 ],  "texture": "#texture" },
+				"up":    { "uv": [ 5, 2, 11, 8 ],  "texture": "#texture" },
 				"north": { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" },
 				"south": { "uv": [ 5, 11, 11, 14 ], "texture": "#texture", "cullface": "south" },
-				"west": { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" },
-				"east": { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" }
+				"west":  { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" },
+				"east":  { "uv": [ 5, 11, 11, 14 ], "texture": "#texture" }
 			}
 		},
 		{
@@ -162,7 +165,7 @@
 				"up": { "uv": [ 5, 8, 11, 9 ], "texture": "#texture" },
 				"south": { "uv": [ 5, 12, 11, 14 ], "texture": "#texture" },
 				"west": { "uv": [ 4, 12, 5, 14 ], "texture": "#texture" },
-				"east": { "uv": [ 11, 11.5, 12, 13.5 ], "texture": "#texture" }
+				"east": { "uv": [ 11, 12, 12, 14 ], "texture": "#texture" }
 			}
 		}
 	]

--- a/src/main/resources/assets/minecraft/models/block/warped_fungus.json
+++ b/src/main/resources/assets/minecraft/models/block/warped_fungus.json
@@ -11,6 +11,7 @@
 			"from": [ 7, 0, 7 ],
 			"to": [ 9, 5, 9 ],
 			"faces": {
+				"down": { "uv": [ 0, 11, 2, 13 ], "texture": "#texture" },
 				"north": { "uv": [ 0, 11, 2, 16 ], "texture": "#texture" },
 				"south": { "uv": [ 0, 11, 2, 16 ], "texture": "#texture" },
 				"west": { "uv": [ 0, 11, 2, 16 ], "texture": "#texture" },


### PR DESCRIPTION
There were some issues with mushroom models, so here's some fixes:

- Mushroom stalks now have a bottom texture (almost impossible to see in normal gameplay and is almost always culled, but #246 makes this change visible)

- One of the brown mushroom textures was missing a cullface, which is now fixed:
![2020-11-17_21 52 31](https://user-images.githubusercontent.com/52297970/100077832-bdaacb80-2e3a-11eb-8283-4c64c56b9bcd.png)
![2020-11-17_21 53 05](https://user-images.githubusercontent.com/52297970/100077834-bf748f00-2e3a-11eb-8974-c17ed421b68a.png)

- Brown wall mushrooms also had a top face that was not culled when expected:
![2020-11-17_21 56 32](https://user-images.githubusercontent.com/52297970/100077933-da470380-2e3a-11eb-9d14-e74757f5d211.png)
![2020-11-24_09 45 53](https://user-images.githubusercontent.com/52297970/100077961-e16e1180-2e3a-11eb-938c-c76a43ad1115.png)
![2020-11-24_09 46 57](https://user-images.githubusercontent.com/52297970/100077974-e3d06b80-2e3a-11eb-8801-97b3a0349ff9.png)

- And one red mushroom model had a weird UV issue:
![2020-11-24_09 43 11](https://user-images.githubusercontent.com/52297970/100078044-f8146880-2e3a-11eb-8bfb-2fc6e6372405.png)
![2020-11-24_09 44 02](https://user-images.githubusercontent.com/52297970/100078048-f8acff00-2e3a-11eb-84ee-add87efe15d8.png)

