### PR TITLE
Fix incompatibility with portable crafting table mods

### DIFF
--- a/src/main/java/paulevs/betternether/mixin/common/CraftingScreenHandlerMixin.java
+++ b/src/main/java/paulevs/betternether/mixin/common/CraftingScreenHandlerMixin.java
@@ -20,9 +20,10 @@ public abstract class CraftingScreenHandlerMixin {
 
 	@Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
 	private void canUse(PlayerEntity player, CallbackInfoReturnable<Boolean> info) {
-		info.setReturnValue(context.run((world, pos) -> {
+		if (context.run((world, pos) -> {
 			return world.getBlockState(pos).getBlock() instanceof CraftingTableBlock;
-		}, true));
-		info.cancel();
+		}, true)) {
+			info.setReturnValue(true);
+		}
 	}
 }


### PR DESCRIPTION
Same fix as paulevsGitch/BetterEnd#43, allows mods to add other conditions for keeping a crafting screen open.