### PR TITLE
en_us, en_gb fixes

### DIFF
--- a/src/main/resources/assets/betternether/lang/en_gb.json
+++ b/src/main/resources/assets/betternether/lang/en_gb.json
@@ -1,3 +1,14 @@
 {
-	"block.betternether.soul_sandstone_chiseled": "Chiselled Soul Sandstone"
+	"block.betternether.soul_sandstone_chiseled": "Chiselled Soul Sandstone",
+	
+	"block.betternether.gray_mold": "Grey Mold",
+	"block.betternether.quartz_glass_gray": "Grey Quartz Glass",
+	"block.betternether.quartz_glass_light_gray": "Light Grey Quartz Glass",
+	"block.betternether.quartz_glass_framed_gray": "Grey Framed Quartz Glass",
+	"block.betternether.quartz_glass_framed_light_gray": "Light Grey Framed Quartz Glass",
+	"block.betternether.quartz_glass_pane_gray": "Grey Quartz Pane",
+	"block.betternether.quartz_glass_pane_light_gray": "Light Grey Quartz Pane",
+	"block.betternether.quartz_glass_framed_pane_gray": "Grey Framed Quartz Pane",
+	"block.betternether.quartz_glass_framed_pane_light_gray": "Light Grey Framed Quartz Pane",
+	
 }

--- a/src/main/resources/assets/betternether/lang/en_gb.json
+++ b/src/main/resources/assets/betternether/lang/en_gb.json
@@ -9,6 +9,6 @@
 	"block.betternether.quartz_glass_pane_gray": "Grey Quartz Pane",
 	"block.betternether.quartz_glass_pane_light_gray": "Light Grey Quartz Pane",
 	"block.betternether.quartz_glass_framed_pane_gray": "Grey Framed Quartz Pane",
-	"block.betternether.quartz_glass_framed_pane_light_gray": "Light Grey Framed Quartz Pane",
+	"block.betternether.quartz_glass_framed_pane_light_gray": "Light Grey Framed Quartz Pane"
 	
 }

--- a/src/main/resources/assets/betternether/lang/en_gb.json
+++ b/src/main/resources/assets/betternether/lang/en_gb.json
@@ -10,5 +10,4 @@
 	"block.betternether.quartz_glass_pane_light_gray": "Light Grey Quartz Pane",
 	"block.betternether.quartz_glass_framed_pane_gray": "Grey Framed Quartz Pane",
 	"block.betternether.quartz_glass_framed_pane_light_gray": "Light Grey Framed Quartz Pane"
-	
 }

--- a/src/main/resources/assets/betternether/lang/en_us.json
+++ b/src/main/resources/assets/betternether/lang/en_us.json
@@ -228,7 +228,7 @@
 	"block.betternether.black_vine": "Black Vine",
 	"block.betternether.veined_sand": "Veined Sand",
 	"block.betternether.soul_vein": "Soul Vein",
-	"block.betternether.blooming_vine": "Blooming vine",
+	"block.betternether.blooming_vine": "Blooming Vine",
 	"block.betternether.golden_vine": "Golden Vine",
 	"block.betternether.geyser": "Geyser",
 	
@@ -589,9 +589,9 @@
 	"block.betternether.warped_ladder": "Warped Ladder",
 	"block.betternether.mushroom_ladder": "Mushroom Ladder",
 	
-	"block.betternether.taburet_crimson": "Crimson Taburet",
-	"block.betternether.taburet_warped": "Warped Taburet",
-	"block.betternether.taburet_mushroom": "Mushroom Taburet",
+	"block.betternether.taburet_crimson": "Crimson Stool",
+	"block.betternether.taburet_warped": "Warped Stool",
+	"block.betternether.taburet_mushroom": "Mushroom Stool",
 	
 	"block.betternether.chair_crimson": "Crimson Chair",
 	"block.betternether.chair_warped": "Warped Chair",
@@ -680,7 +680,7 @@
 	"block.betternether.sign_nether_sakura": "Nether Sakura Sign",
 	"block.betternether.striped_bark_nether_sakura": "Stripped Nether Sakura Bark",
 	"block.betternether.striped_log_nether_sakura": "Stripped Nether Sakura Log",
-	"block.betternether.taburet_nether_sakura": "Nether Sakura Taburet",
+	"block.betternether.taburet_nether_sakura": "Nether Sakura Stool",
 	
 	"block.betternether.nether_sakura_leaves": "Nether Sakura Leaves",
 	"block.betternether.nether_sakura_sapling": "Nether Sakura Sapling",


### PR DESCRIPTION
I didn't want to create two entire issues for two small bugs in these language files, so I figured I would simply fix them.
- "Blooming vine" capitalization fixed
- #309 fixed
- "Gray" replaced with British English "Grey" in en_gb for glass blocks and grey mold