### PR TITLE
SilkTouch for vines and leaves

### DIFF
--- a/src/main/java/paulevs/betternether/blocks/BlockAnchorTreeLeaves.java
+++ b/src/main/java/paulevs/betternether/blocks/BlockAnchorTreeLeaves.java
@@ -65,7 +65,7 @@ public class BlockAnchorTreeLeaves extends BlockBaseNotFull {
 	@Override
 	public List<ItemStack> getDroppedStacks(BlockState state, LootContext.Builder builder) {
 		ItemStack tool = builder.get(LootContextParameters.TOOL);
-		if (tool != null && FabricToolTags.SHEARS.contains(tool.getItem()) || EnchantmentHelper.getLevel(Enchantments.SILK_TOUCH, tool) > 0) {
+		if (tool != null && (FabricToolTags.SHEARS.contains(tool.getItem()) || EnchantmentHelper.getLevel(Enchantments.SILK_TOUCH, tool) > 0)) {
 			return Lists.newArrayList(new ItemStack(this.asItem()));
 		}
 		else {

--- a/src/main/java/paulevs/betternether/blocks/BlockBlackVine.java
+++ b/src/main/java/paulevs/betternether/blocks/BlockBlackVine.java
@@ -14,7 +14,6 @@ import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.state.StateManager;
-import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockPos.Mutable;
 import net.minecraft.util.math.Direction;
@@ -30,23 +29,22 @@ import java.util.Random;
 
 public class BlockBlackVine extends BlockBaseNotFull implements Fertilizable {
 	private static final VoxelShape SHAPE = Block.createCuboidShape(2, 0, 2, 14, 16, 14);
-	public static final BooleanProperty BOTTOM = BlockProperties.BOTTOM;
 
 	public BlockBlackVine() {
 		super(FabricBlockSettings.of(Material.PLANT)
-				.materialColor(MapColor.RED)
+				.mapColor(MapColor.RED)
 				.sounds(BlockSoundGroup.CROP)
 				.noCollision()
 				.breakInstantly()
 				.nonOpaque());
 		this.setRenderLayer(BNRenderLayer.CUTOUT);
 		this.setDropItself(false);
-		this.setDefaultState(getStateManager().getDefaultState().with(BOTTOM, true));
+		this.setDefaultState(getStateManager().getDefaultState().with(BlockProperties.BOTTOM, true));
 	}
 
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> stateManager) {
-		stateManager.add(BOTTOM);
+		stateManager.add(BlockProperties.BOTTOM);
 	}
 
 	@Override
@@ -73,7 +71,7 @@ public class BlockBlackVine extends BlockBaseNotFull implements Fertilizable {
 	@Override
 	public BlockState getStateForNeighborUpdate(BlockState state, Direction facing, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
 		if (canPlaceAt(state, world, pos))
-			return world.getBlockState(pos.down()).getBlock() == this ? state.with(BOTTOM, false) : state.with(BOTTOM, true);
+			return world.getBlockState(pos.down()).getBlock() == this ? state.with(BlockProperties.BOTTOM, false) : state.with(BlockProperties.BOTTOM, true);
 		else
 			return Blocks.AIR.getDefaultState();
 	}
@@ -102,8 +100,8 @@ public class BlockBlackVine extends BlockBaseNotFull implements Fertilizable {
 			if (world.getBlockState(blockPos).getBlock() != this)
 				break;
 		}
-		BlocksHelper.setWithoutUpdate(world, blockPos.up(), getDefaultState().with(BOTTOM, false));
-		BlocksHelper.setWithoutUpdate(world, blockPos, getDefaultState().with(BOTTOM, true));
+		BlocksHelper.setWithoutUpdate(world, blockPos.up(), getDefaultState().with(BlockProperties.BOTTOM, false));
+		BlocksHelper.setWithoutUpdate(world, blockPos, getDefaultState().with(BlockProperties.BOTTOM, true));
 	}
 
 	@Override

--- a/src/main/java/paulevs/betternether/blocks/BlockWhisperingGourdVine.java
+++ b/src/main/java/paulevs/betternether/blocks/BlockWhisperingGourdVine.java
@@ -6,6 +6,8 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.block.*;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -109,7 +111,7 @@ public class BlockWhisperingGourdVine extends BlockBaseNotFull implements Fertil
 	@Override
 	public List<ItemStack> getDroppedStacks(BlockState state, LootContext.Builder builder) {
 		ItemStack tool = builder.get(LootContextParameters.TOOL);
-		if (tool != null && FabricToolTags.SHEARS.contains(tool.getItem()))
+		if (tool != null && (FabricToolTags.SHEARS.contains(tool.getItem()) || EnchantmentHelper.getLevel(Enchantments.SILK_TOUCH, tool) > 0))
 			return Lists.newArrayList(new ItemStack(this.asItem()));
 		else if (state.get(SHAPE) == TripleShape.BOTTOM || MHelper.RANDOM.nextBoolean())
 			return Lists.newArrayList(new ItemStack(this.asItem()));

--- a/src/main/java/paulevs/betternether/mixin/common/LeavesBlockMixin.java
+++ b/src/main/java/paulevs/betternether/mixin/common/LeavesBlockMixin.java
@@ -23,7 +23,7 @@ public abstract class LeavesBlockMixin extends Block {
 	@Override
 	public List<ItemStack> getDroppedStacks(BlockState state, LootContext.Builder builder) {
 		ItemStack tool = builder.get(LootContextParameters.TOOL);
-		if (tool != null && (FabricToolTags.SHEARS.contains(tool.getItem()) || EnchantmentHelper.getLevel(Enchantments.SILK_TOUCH, tool) > 0)) {
+		if (tool != null && FabricToolTags.SHEARS.contains(tool.getItem())) {
 			return Collections.singletonList(new ItemStack(this.asItem()));
 		}
 		else {

--- a/src/main/java/paulevs/betternether/mixin/common/LeavesBlockMixin.java
+++ b/src/main/java/paulevs/betternether/mixin/common/LeavesBlockMixin.java
@@ -2,6 +2,9 @@ package paulevs.betternether.mixin.common;
 
 import java.util.Collections;
 import java.util.List;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
 import org.spongepowered.asm.mixin.Mixin;
 import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.block.Block;
@@ -20,7 +23,7 @@ public abstract class LeavesBlockMixin extends Block {
 	@Override
 	public List<ItemStack> getDroppedStacks(BlockState state, LootContext.Builder builder) {
 		ItemStack tool = builder.get(LootContextParameters.TOOL);
-		if (tool != null && FabricToolTags.SHEARS.contains(tool.getItem())) {
+		if (tool != null && (FabricToolTags.SHEARS.contains(tool.getItem()) || EnchantmentHelper.getLevel(Enchantments.SILK_TOUCH, tool) > 0)) {
 			return Collections.singletonList(new ItemStack(this.asItem()));
 		}
 		else {

--- a/src/main/java/paulevs/betternether/structures/plants/StructureVine.java
+++ b/src/main/java/paulevs/betternether/structures/plants/StructureVine.java
@@ -6,7 +6,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockPos.Mutable;
 import net.minecraft.world.ServerWorldAccess;
 import paulevs.betternether.BlocksHelper;
-import paulevs.betternether.blocks.BlockBlackVine;
+import paulevs.betternether.blocks.BlockProperties;
 import paulevs.betternether.structures.IStructure;
 
 import java.util.Random;
@@ -27,8 +27,8 @@ public class StructureVine implements IStructure {
 			return;
 		h = random.nextInt(h) + 1;
 
-		BlockState bottom = block.getDefaultState().with(BlockBlackVine.BOTTOM, true);
-		BlockState middle = block.getDefaultState().with(BlockBlackVine.BOTTOM, false);
+		BlockState bottom = block.getDefaultState().with(BlockProperties.BOTTOM, true);
+		BlockState middle = block.getDefaultState().with(BlockProperties.BOTTOM, false);
 
 		blockPos.set(pos);
 		for (int y = 0; y < h; y++) {


### PR DESCRIPTION
 - Enables all leaves and vines that previously could be mined using shears to drop when using a tool with SilkTouch.
 - Removes a possible crash where a tool could be null in the `AnchorTreeLeave` test
 - Removed "alias"-Field `BOTTOM` in `BlockBlackVine`