### PR TITLE
Smooth Soul Sandstone crafting/smelting changes

### DIFF
--- a/src/main/java/paulevs/betternether/registry/NetherBlocks.java
+++ b/src/main/java/paulevs/betternether/registry/NetherBlocks.java
@@ -258,7 +258,7 @@ public class NetherBlocks extends ru.bclib.registry.BlockRegistry {
 	public static final Block BLUE_OBSIDIAN_GLASS_PANE = registerBlock("blue_obsidian_glass_pane", new BNPane(BLUE_OBSIDIAN_GLASS, true));
 	
 	// Soul Sandstone //
-	public static final Block SOUL_SANDSTONE = registerBlock("soul_sandstone", new BlockSoulSandstone(), BlockTags.SOUL_SPEED_BLOCKS, BlockTags.SOUL_FIRE_BASE_BLOCKS);
+	public static final Block SOUL_SANDSTONE = registerSoulBlock("soul_sandstone", new BlockSoulSandstone());
 	public static final Block SOUL_SANDSTONE_CUT = registerMakeable2X2Soul("soul_sandstone_cut", new BlockSoulSandstone(), "soul_sandstone", SOUL_SANDSTONE);
 	public static final Block SOUL_SANDSTONE_SMOOTH = registerSoulBlock("soul_sandstone_smooth", new BlockBase(FabricBlockSettings.copyOf(Blocks.SANDSTONE)));
 	public static final Block SOUL_SANDSTONE_CHISELED = registerMakeable2X2Soul("soul_sandstone_chiseled", new BlockBase(FabricBlockSettings.copyOf(Blocks.SANDSTONE)), "soul_sandstone", SOUL_SANDSTONE_SMOOTH);
@@ -591,10 +591,8 @@ public class NetherBlocks extends ru.bclib.registry.BlockRegistry {
 		return plate;
 	}
 
-	public static Block registerSoulBlock(String name, Block result) {
-		Block block = registerBlockDirectly(name, result);
-		TagAPI.addTags(block, BlockTags.SOUL_FIRE_BASE_BLOCKS, BlockTags.SOUL_SPEED_BLOCKS);
-		return block;
+	public static Block registerSoulBlock(String name, Block block) {
+		return registerBlock(name, block, BlockTags.SOUL_FIRE_BASE_BLOCKS, BlockTags.SOUL_SPEED_BLOCKS);		
 	}
 	
 	public static Block registerMakeable2X2Soul(String name, Block result, String group, Block... sources) {

--- a/src/main/java/paulevs/betternether/registry/NetherBlocks.java
+++ b/src/main/java/paulevs/betternether/registry/NetherBlocks.java
@@ -260,7 +260,7 @@ public class NetherBlocks extends ru.bclib.registry.BlockRegistry {
 	// Soul Sandstone //
 	public static final Block SOUL_SANDSTONE = registerBlock("soul_sandstone", new BlockSoulSandstone(), BlockTags.SOUL_SPEED_BLOCKS, BlockTags.SOUL_FIRE_BASE_BLOCKS);
 	public static final Block SOUL_SANDSTONE_CUT = registerMakeable2X2Soul("soul_sandstone_cut", new BlockSoulSandstone(), "soul_sandstone", SOUL_SANDSTONE);
-	public static final Block SOUL_SANDSTONE_SMOOTH = registerMakeable2X2Soul("soul_sandstone_smooth", new BlockBase(FabricBlockSettings.copyOf(Blocks.SANDSTONE)), "soul_sandstone", SOUL_SANDSTONE_CUT);
+	public static final Block SOUL_SANDSTONE_SMOOTH = registerSoulBlock("soul_sandstone_smooth", new BlockBase(FabricBlockSettings.copyOf(Blocks.SANDSTONE)));
 	public static final Block SOUL_SANDSTONE_CHISELED = registerMakeable2X2Soul("soul_sandstone_chiseled", new BlockBase(FabricBlockSettings.copyOf(Blocks.SANDSTONE)), "soul_sandstone", SOUL_SANDSTONE_SMOOTH);
 	
 	public static final Block SOUL_SANDSTONE_STAIRS = registerStairs("soul_sandstone_stairs", SOUL_SANDSTONE, BlockTags.SOUL_SPEED_BLOCKS, BlockTags.SOUL_FIRE_BASE_BLOCKS);
@@ -589,6 +589,12 @@ public class NetherBlocks extends ru.bclib.registry.BlockRegistry {
 			RecipesHelper.makePlateRecipe(source, plate);
 		}
 		return plate;
+	}
+
+	public static Block registerSoulBlock(String name, Block result) {
+		Block block = registerBlockDirectly(name, result);
+		TagAPI.addTags(block, BlockTags.SOUL_FIRE_BASE_BLOCKS, BlockTags.SOUL_SPEED_BLOCKS);
+		return block;
 	}
 	
 	public static Block registerMakeable2X2Soul(String name, Block result, String group, Block... sources) {

--- a/src/main/resources/data/betternether/recipes/soul_sandstone.json
+++ b/src/main/resources/data/betternether/recipes/soul_sandstone.json
@@ -1,16 +1,9 @@
 {
-  "type": "minecraft:crafting_shaped",
-  "pattern": [
-    "##",
-    "##"
-  ],
-  "key": {
-    "#": {
-      "tag": "c:soul_ground"
-    }
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "betternether:soul_sandstone"
   },
-  "result": {
-    "item": "betternether:soul_sandstone",
-	"count": 4
-  }
+  "result": "betternether:soul_sandstone_smooth",
+  "experience": 0.1,
+  "cookingtime": 200
 }


### PR DESCRIPTION
Based on the issue: https://github.com/paulevsGitch/BetterNether/issues/345

- Adjust Smooth Soul Standstone to not be craftable from cut soul sandstone
- Add a new smelting receipe for soul sandstone into smoooth soul sandstone