### PR TITLE
Disabled BetterNether's fix BetterNether/pull/437 so it can be migrated to BCLib on paulevsGitch/BCLib/pull/45

### DIFF
--- a/src/main/java/paulevs/betternether/mixin/common/LayerLightSectionStorageMixin.java
+++ b/src/main/java/paulevs/betternether/mixin/common/LayerLightSectionStorageMixin.java
@@ -1,3 +1,4 @@
+/**
 package paulevs.betternether.mixin.common;
 
 import net.minecraft.core.BlockPos;
@@ -38,3 +39,4 @@ public class LayerLightSectionStorageMixin {
 	}
 
 }
+**/

--- a/src/main/resources/betternether.mixins.common.json
+++ b/src/main/resources/betternether.mixins.common.json
@@ -14,7 +14,6 @@
       "DeltaFeatureMixin",
       "GenerationSettingsAccessor",
       "LeavesBlockMixin",
-      "LayerLightSectionStorageMixin",
       "MapMixin",
       "MapStateMixin",
       "MinecraftServerMixin",


### PR DESCRIPTION
Moved BetterNether's crash fix PR to BCLib as BetterEnd also crashed with the same issue.
Closes BCLib's [#43](https://github.com/paulevsGitch/BCLib/issues/43).