### PR TITLE
Replace usage of internal fabric mixins with our own accessors

### DIFF
--- a/src/main/java/paulevs/betternether/blocks/BNLeaves.java
+++ b/src/main/java/paulevs/betternether/blocks/BNLeaves.java
@@ -2,13 +2,13 @@ package paulevs.betternether.blocks;
 
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricMaterialBuilder;
-import net.fabricmc.fabric.mixin.object.builder.AbstractBlockSettingsAccessor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
+import paulevs.betternether.mixin.common.BlockBehaviourPropertiesAccessor;
 import ru.bclib.blocks.BaseLeavesBlock;
 
 import java.util.Random;
@@ -19,7 +19,7 @@ public class BNLeaves extends BaseLeavesBlock {
 	
 	public BNLeaves(Block sapling, MaterialColor color) {
 		super(sapling, color, (settings)-> {
-			AbstractBlockSettingsAccessor accessor = (AbstractBlockSettingsAccessor)settings;
+			BlockBehaviourPropertiesAccessor accessor = (BlockBehaviourPropertiesAccessor) settings;
 			accessor.setMaterial(NETHER_LEAVES);
 		});
 	}
@@ -27,7 +27,7 @@ public class BNLeaves extends BaseLeavesBlock {
 	public BNLeaves(Block sapling, MaterialColor color, Consumer<FabricBlockSettings> customizeProperties) {
 		super(sapling, color, (settings)-> {
 			customizeProperties.accept(settings);
-			AbstractBlockSettingsAccessor accessor = (AbstractBlockSettingsAccessor)settings;
+			BlockBehaviourPropertiesAccessor accessor = (BlockBehaviourPropertiesAccessor) settings;
 			accessor.setMaterial(NETHER_LEAVES);
 		});
 	}

--- a/src/main/java/paulevs/betternether/commands/CommandRegistry.java
+++ b/src/main/java/paulevs/betternether/commands/CommandRegistry.java
@@ -10,8 +10,6 @@ import com.mojang.datafixers.util.Either;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.math.Vector3d;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
-import net.fabricmc.fabric.mixin.object.builder.AbstractBlockAccessor;
-import net.fabricmc.fabric.mixin.object.builder.AbstractBlockSettingsAccessor;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -41,6 +39,8 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import paulevs.betternether.BlocksHelper;
 import paulevs.betternether.MHelper;
+import paulevs.betternether.mixin.common.BlockBehaviourAccessor;
+import paulevs.betternether.mixin.common.BlockBehaviourPropertiesAccessor;
 import paulevs.betternether.registry.NetherBiomes;
 import paulevs.betternether.registry.NetherBlocks;
 import paulevs.betternether.world.NetherBiome;
@@ -325,8 +325,8 @@ public class CommandRegistry {
         List<Block> other = new LinkedList<>();
 
         for (Block block : NetherBlocks.getModBlocks().stream().sorted(CommandRegistry::compareBlockNames).collect(Collectors.toList())) {
-            BlockBehaviour.Properties properties = ((AbstractBlockAccessor) block).getSettings();
-            Material material = ((AbstractBlockSettingsAccessor) properties).getMaterial();
+            BlockBehaviour.Properties properties = ((BlockBehaviourAccessor) block).getProperties();
+            Material material = ((BlockBehaviourPropertiesAccessor) properties).getMaterial();
 
             if (material.equals(Material.STONE) || material.equals(Material.METAL)) {
                 pickaxes.add(block);

--- a/src/main/java/paulevs/betternether/loot/BNLoot.java
+++ b/src/main/java/paulevs/betternether/loot/BNLoot.java
@@ -2,7 +2,6 @@ package paulevs.betternether.loot;
 
 import net.fabricmc.fabric.api.loot.v1.FabricLootPoolBuilder;
 import net.fabricmc.fabric.api.loot.v1.event.LootTableLoadingCallback;
-import net.fabricmc.fabric.mixin.loot.table.LootSupplierBuilderHooks;
 import net.minecraft.world.level.storage.loot.BuiltInLootTables;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.level.storage.loot.entries.EmptyLootItem;
@@ -10,6 +9,7 @@ import net.minecraft.world.level.storage.loot.entries.LootItem;
 import net.minecraft.world.level.storage.loot.functions.SetItemCountFunction;
 import net.minecraft.world.level.storage.loot.providers.number.UniformGenerator;
 import paulevs.betternether.BetterNether;
+import paulevs.betternether.mixin.common.LootTableBuilderAccessor;
 import paulevs.betternether.registry.NetherBlocks;
 
 import java.lang.reflect.Field;
@@ -61,9 +61,9 @@ public class BNLoot {
 				try {
 					for (Field f : table.getClass()
 										.getDeclaredFields()) {
-						if (LootSupplierBuilderHooks.class.isAssignableFrom(f.getType())) {
+						if (LootTableLoadingCallback.class.isAssignableFrom(f.getType())) {
 							f.setAccessible(true);
-							LootSupplierBuilderHooks hook = (LootSupplierBuilderHooks) f.get(table);
+							LootTableBuilderAccessor hook = (LootTableBuilderAccessor) f.get(table);
 							if (hook != null) {
 								pools = hook.getPools();
 							}

--- a/src/main/java/paulevs/betternether/mixin/common/BlockBehaviourAccessor.java
+++ b/src/main/java/paulevs/betternether/mixin/common/BlockBehaviourAccessor.java
@@ -1,0 +1,11 @@
+package paulevs.betternether.mixin.common;
+
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(BlockBehaviour.class)
+public interface BlockBehaviourAccessor {
+	@Accessor("properties")
+	BlockBehaviour.Properties getProperties();
+}

--- a/src/main/java/paulevs/betternether/mixin/common/BlockBehaviourPropertiesAccessor.java
+++ b/src/main/java/paulevs/betternether/mixin/common/BlockBehaviourPropertiesAccessor.java
@@ -1,0 +1,15 @@
+package paulevs.betternether.mixin.common;
+
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.Material;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(BlockBehaviour.Properties.class)
+public interface BlockBehaviourPropertiesAccessor {
+	@Accessor("material")
+	Material getMaterial();
+
+	@Accessor("material")
+	void setMaterial(Material material);
+}

--- a/src/main/java/paulevs/betternether/mixin/common/LootTableBuilderAccessor.java
+++ b/src/main/java/paulevs/betternether/mixin/common/LootTableBuilderAccessor.java
@@ -1,0 +1,18 @@
+package paulevs.betternether.mixin.common;
+
+import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(LootTable.Builder.class)
+public interface LootTableBuilderAccessor {
+	@Accessor("pools")
+	List<LootPool> getPools();
+
+	@Accessor("functions")
+	List<LootItemFunction> getFunctions();
+}

--- a/src/main/java/paulevs/betternether/registry/NetherTags.java
+++ b/src/main/java/paulevs/betternether/registry/NetherTags.java
@@ -1,8 +1,5 @@
 package paulevs.betternether.registry;
 
-import net.fabricmc.fabric.mixin.object.builder.AbstractBlockAccessor;
-import net.fabricmc.fabric.mixin.object.builder.AbstractBlockSettingsAccessor;
-import net.minecraft.tags.Tag;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -12,6 +9,8 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.Material;
 import paulevs.betternether.blocks.BlockTerrain;
 import paulevs.betternether.blocks.materials.Materials;
+import paulevs.betternether.mixin.common.BlockBehaviourAccessor;
+import paulevs.betternether.mixin.common.BlockBehaviourPropertiesAccessor;
 import ru.bclib.api.BonemealAPI;
 import ru.bclib.api.ComposterAPI;
 import ru.bclib.api.tag.NamedBlockTags;
@@ -37,8 +36,8 @@ public class NetherTags {
 	public static void register() {
 		TagAPI.addBlockTag(NETHER_SAND_LOCATION, Blocks.SOUL_SAND);
 		NetherBlocks.getModBlocks().forEach(block -> {
-			BlockBehaviour.Properties properties = ((AbstractBlockAccessor) block).getSettings();
-			Material material = ((AbstractBlockSettingsAccessor) properties).getMaterial();
+			BlockBehaviour.Properties properties = ((BlockBehaviourAccessor) block).getProperties();
+			Material material = ((BlockBehaviourPropertiesAccessor) properties).getMaterial();
 			Item item = block.asItem();
 
 			if (material.equals(Material.STONE) || material.equals(Material.METAL)) {

--- a/src/main/resources/betternether.mixins.common.json
+++ b/src/main/resources/betternether.mixins.common.json
@@ -25,6 +25,9 @@
 		"BlockBehaviourMixin",
 		"PlayerEntityMixin",
 		"RecipeManagerAccessor",
+		"BlockBehaviourAccessor",
+		"BlockBehaviourPropertiesAccessor",
+		"LootTableBuilderAccessor",
 		"RecipeManagerMixin"
 	],
 	"injectors": {


### PR DESCRIPTION
Fabric considers the classes in the `net.fabricmc.fabric.mixin` package internal because they can be changed/removed completely at any time. Fixes #544.