### PR TITLE
Properly tag betternether's biomes as minecraft:is_nether for 1.18.2

### DIFF
--- a/src/main/resources/data/minecraft/tags/worldgen/biome/is_nether.json
+++ b/src/main/resources/data/minecraft/tags/worldgen/biome/is_nether.json
@@ -1,0 +1,27 @@
+{
+  "replace": false,
+  "values": [
+    "betternether:bone_reef",
+    "betternether:crimson_glowing_woods",
+    "betternether:crimson_pinewood",
+    "betternether:flooded_deltas",
+    "betternether:gravel_desert",
+    "betternether:magma_land",
+    "betternether:nether_grasslands",
+    "betternether:nether_jungle",
+    "betternether:nether_mushroom_forest",
+    "betternether:nether_mushroom_forest_edge",
+    "betternether:nether_swampland",
+    "betternether:nether_swampland_terraces",
+    "betternether:old_fungiwoods",
+    "betternether:old_swampland",
+    "betternether:old_warped_woods",
+    "betternether:poor_nether_grasslands",
+    "betternether:soul_plain",
+    "betternether:sulfuric_bone_reef",
+    "betternether:upside_down_forest",
+    "betternether:upside_down_forest_cleared",
+    "betternether:wart_forest",
+    "betternether:wart_forest_edge"
+  ]
+}


### PR DESCRIPTION
With the creation of biome tags in 1.18.2 by mojang, all biome mods should now properly tag their biomes to maximize compat. Currently, mods and datapacks using the minecraft:is_nether biome tag for their json structures will not spawn in betternether biomes. Which is problematic. 

This aims to resolve that. 

Minecraft's biome tags: https://minecraft.fandom.com/wiki/Tag#biomes_is_nether